### PR TITLE
feat(website): add ads.txt and adsense meta tag for alternative verif…

### DIFF
--- a/website/ads.txt
+++ b/website/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-5425029423334959, DIRECT, f08c47fec0942fa0

--- a/website/index.html
+++ b/website/index.html
@@ -25,6 +25,7 @@
 
   <link rel="stylesheet" href="styles.css?v=3" />
   <!-- Google AdSense -->
+  <meta name="google-adsense-account" content="ca-pub-5425029423334959" />
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5425029423334959"
     crossorigin="anonymous"></script>
 


### PR DESCRIPTION
## Summary
This PR adds two alternative verification methods (HTML `<meta>` tag and `ads.txt` file) to resolve the Google AdSense crawler verification failure on our Netlify subdomain.

## Why this is needed & How it works
The standard JavaScript script tag was failing to verify because the Google crawler struggled to dynamically process it on `cricstatz.netlify.app`. 

To bypass this issue, we added the other two verification mechanisms supported by AdSense:
1. **HTML Meta Tag**: Added `<meta name="google-adsense-account" content="ca-pub-5425029423334959" />` to the `<head>` of `website/index.html`. 
2. **Ads.txt file**: Created a new root-level file at `website/ads.txt` with:
   `google.com, pub-5425029423334959, DIRECT, f08c47fec0942fa0`

## Type of Change
- [x] Feature (Alternative Verification Methods)
- [ ] Bug fix
- [ ] Docs
- [ ] Design assets
- [ ] Refactor/chore

## Linked Issue
Closes #48 

## What Was Tested
- Verified the local files build and resolve correctly.
- Confirmed that the `ads.txt` will be served at the root URL (e.g. `/ads.txt`) via the Netlify `publish = "website"` configuration.

## Checklist
- [x] I followed the project structure and naming conventions
- [x] I did not commit secrets or credentials (only the public AdSense publisher ID)
- [x] My changes are focused and reviewable
